### PR TITLE
Remove unsupported parameter max_length of slugify()

### DIFF
--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -174,8 +174,8 @@ class Ghost(object):
                 self.nvim.buffers[bufnr][:] = req["text"].split("\n")
             else:
                 # new client
-                prefix = "ghost-" + req["url"] + "-" + slugify(req["title"],
-                                                               max_length=50)
+                prefix = "ghost-" + req["url"] + "-" + \
+                    slugify(req["title"])[:50]
                 temp_file_handle, temp_file_name = mkstemp(prefix=prefix,
                                                            suffix=".txt",
                                                            text=True)


### PR DESCRIPTION
Not only ``slugify()`` doesn't accept max_length parameter, but it is completely unnecessary. Good old Python slice works perfectly for limiting string to maximal length, because if ``mystring`` is shorter than ``MAX_LENGTH`` then ``mystring[:MAX_LENGTH]`` just does nothing.

Fixes #3