### PR TITLE
Two different features…

### DIFF
--- a/doc/ghost.txt
+++ b/doc/ghost.txt
@@ -95,6 +95,11 @@ To disable ghost, use
 >
     let g:loaded_ghost = 1
 
+By default the temporary files are opend with |:edit| but you can use any
+command you like (|:split|, |:vsplit|, |:tabedit|, etc.) like this
+>
+    let g:ghost_cmd = 'tabedit'
+
 vim-ghost creates files with a prefix like so - `ghost-<domain>-<titleslug>-<random>.txt`
 You can use this to set up options specific to a domain - like so:
 

--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -92,6 +92,7 @@ class Ghost(object):
         self.winapp = None
         self.darwinapp = None
         self.linux_window_id = None
+        self.cmd = 'ed'
 
     @neovim.command('GhostStart', range='', nargs='0')
     def server_start(self, args, range):
@@ -105,6 +106,11 @@ class Ghost(object):
             self.port = self.nvim.api.get_var("ghost_port")
         else:
             self.nvim.api.set_var("ghost_port", self.port)
+
+        if self.nvim.funcs.exists("g:ghost_cmd") == 1:
+            self.cmd = self.nvim.api.get_var("ghost_cmd")
+        else:
+            self.nvim.api.set_var("ghost_cmd", self.cmd)
 
         self.httpserver = MyHTTPServer(self, ('127.0.0.1', self.port),
                                        WebRequestHandler)
@@ -187,7 +193,7 @@ class Ghost(object):
                 temp_file_handle, temp_file_name = mkstemp(prefix=prefix,
                                                            suffix=".txt",
                                                            text=True)
-                self.nvim.command("ed %s" % temp_file_name)
+                self.nvim.command("%s %s" % (self.cmd, temp_file_name))
                 self.nvim.current.buffer[:] = req["text"].split("\n")
                 bufnr = self.nvim.current.buffer.number
                 delete_cmd = ("au BufDelete <buffer> call"


### PR DESCRIPTION
Raise window on OSX using osascript

Add an option to open the temporary files in a new tab/split.

Sorry, I had a hard time being consistent with the old %-style formatting of Python, I really think you should change everything to f-strings ;)