### PR TITLE
Fix crash on other terminals

### DIFF
--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -139,7 +139,7 @@ class Ghost(object):
                 self.darwinapp = "iTerm2"
             elif os.getenv('TERM_PROGRAM', None) == 'Apple_Terminal':
                 self.darwinapp = "Terminal"
-            logger.debug(self.darwinapp + " detected")
+            logger.debug("%s detected" % self.darwinapp)
 
     @neovim.command('GhostStop', range='', nargs='0', sync=True)
     def server_stop(self, args, range):


### PR DESCRIPTION
If terminal detection failed, `nvim +GhostStart` will crash with this
error:

```
error caught in async handler '/Users/gib/.local/share/nvim/plugged/vim-ghost/rplugin/python3/ghost.py:command:GhostStart [[], [1, 1]]'
Traceback (most recent call last):
  File "/Users/gib/.local/share/nvim/plugged/vim-ghost/rplugin/python3/ghost.py", line 144, in server_start
    logger.debug(self.darwinapp + " detected")
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```