### PR TITLE
Add macOS support for the Kitty terminal

### DIFF
--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -139,6 +139,8 @@ class Ghost(object):
                 self.darwinapp = "iTerm2"
             elif os.getenv('TERM_PROGRAM', None) == 'Apple_Terminal':
                 self.darwinapp = "Terminal"
+            elif os.getenv('KITTY_WINDOW_ID', None):
+                self.darwinapp = 'kitty'
             logger.debug("%s detected" % self.darwinapp)
 
     @neovim.command('GhostStop', range='', nargs='0', sync=True)


### PR DESCRIPTION
I tested and this does raise the terminal for me with Kitty on macOS.

Terminal homepage here: https://sw.kovidgoyal.net/kitty/

Refs: https://github.com/kovidgoyal/kitty/issues/957