### PR TITLE
Allow the user to set the macOS Vim app name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ Plug 'raghur/vim-ghost', {'do': ':GhostInstall'}
 
 * Recent neovim/vim
 * Python 3.4+
-* Python plugin host - `python3 -c 'import neovim'` should not error
+* Python plugin host - `python3 -c 'import pynvim'` should not error
 * Python websocket server https://github.com/dpallot/simple-websocket-server.git
 ** This is automatically installed as a `pip --user` dependency when `:GhostInstall` runs.
 
@@ -31,28 +31,29 @@ Plug 'raghur/vim-ghost', {'do': ':GhostInstall'}
 
 [source,vimscript]
 ----
-Plug 'roxma/nvim-yarp', {'cond': v:version == 800 && !has('nvim')}
-Plug 'roxma/vim-hug-neovim-rpc',  {'cond': v:version == 800 && !has('nvim')}
-
+" Only enabled for Vim 8 (not for Neovim).
+Plug 'roxma/nvim-yarp', v:version == 800 && !has('nvim') ? {} : { 'on': [], 'for': [] }
+Plug 'roxma/vim-hug-neovim-rpc', v:version == 800 && !has('nvim') ? {} : { 'on': [], 'for': [] }
 ----
 
 == Auto switching to vim:
 
 ._Optional, but highly recommended - Switching focus to Neovim_
-* Linux: The `xdotool` command - if available, will be used to focus the nvim window. 
+* Linux: The `xdotool` command - if available, will be used to focus the nvim window.
 Works in console, tmux or guis like neovim-qt
 ** On Ubuntu, you can install it with `sudo apt-get install xdotool`
+* macOS: Set the `g:ghost_darwin_app` variable to the name of your app (see docs).
 * Windows: If pywinauto (https://github.com/pywinauto/pywinauto)
 is available, it will be used to bring the neovim-qt to foreground.
 +
 [source,shell]
 ----
-# Ensure that you install this module for the version of python 
+# Ensure that you install this module for the version of python
 # that is loaded in neovim
 pip install pywinauto
 ----
 Limitations: Currently, on windows, the processname is hardcoded to nvim-qt
-If you use any of the other GUIs for neovim (OniVim, gonvim etc) then this 
+If you use any of the other GUIs for neovim (OniVim, gonvim etc) then this
 will not work.
 
 == Rationale

--- a/doc/ghost.txt
+++ b/doc/ghost.txt
@@ -60,6 +60,9 @@ is available, it will be used to bring the neovim-qt to foreground.
     # that is loaded in neovim
     pip install pywinauto
 
+macOS: Set the g:ghost_darwin_app variable to launch the correct app. See its
+docs for more info.
+
 Limitations: Currently, on windows, the processname is hardcoded to nvim-qt
 If you use any of the other GUIs for neovim (OniVim, gonvim etc) then this 
 will not work.
@@ -82,26 +85,63 @@ You can shutdown the server with :GhostStop
 ================================================================================
 Configuration                                               *GhostConfiguration*
 
-There's very little to configure. If you need to change the port on which the
-server listens, then set g:ghost_port (defaults to 4001 if unset)
+You can configure vim-ghost by setting these options in your vimrc. You will
+need to restart vim-ghost (or restart vim) for them to take effect.
+
+--------------------------------------------------------------------------------
+                                                                  *g:ghost_port*
+Change the port on which the server listens.
 >
     let g:ghost_port = 5678
+<
+Default: 4001
 
-If you'd like to start Ghost on nvim startup, then add this to your .vimrc
+--------------------------------------------------------------------------------
+                                                             *g:ghost_autostart*
+Start Ghost on nvim startup.
 >
     let g:ghost_autostart = 1
+<
+Default: 0
 
-To disable ghost, use
+--------------------------------------------------------------------------------
+                                                                *g:loaded_ghost*
+Disable ghost.
 >
     let g:loaded_ghost = 1
+<
+Default: 0
 
-By default the temporary files are opened with |:edit| but you can use any
-command you like (|:split|, |:vsplit|, |:tabedit|, etc.) like this
+--------------------------------------------------------------------------------
+                                                                   *g:ghost_cmd*
+Use a different command to open temporary files.
+Examples: |:split|, |:vsplit|, |:tabedit|, etc.
 >
     let g:ghost_cmd = 'tabedit'
+<
+Default: |edit|
 
-vim-ghost creates files with a prefix like so - `ghost-<domain>-<titleslug>-<random>.txt`
-You can use this to set up options specific to a domain - like so:
+--------------------------------------------------------------------------------
+                                                            *g:ghost_darwin_app*
+Specify the macOS app you run vim-ghost in (usually your terminal app for
+terminal vim, or the vim program for GUI vim.
+
+You can check by running this command from inside vim:
+>
+   :!osascript -e 'tell application "System Events"' -e 'name of first application process whose frontmost is true' -e 'end tell'
+<
+Examples: 'Terminal', 'iTerm2', 'VimR', 'MacVim', 'kitty'
+>
+    let g:ghost_cmd = 'Terminal'
+<
+Default: ''
+
+--------------------------------------------------------------------------------
+
+Syntax Highlighting
+
+  vim-ghost creates files with a prefix like so - `ghost-<domain>-<titleslug>-<random>.txt`
+  You can use this to set up options specific to a domain - like so:
 
 >
     augroup ghost

--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -118,7 +118,7 @@ class Ghost(object):
         self.server_started = False
         self.port = 4001
         self.winapp = None
-        self.darwinapp = None
+        self.darwin_app = None
         self.linux_window_id = None
         self.cmd = 'ed'
 
@@ -155,6 +155,8 @@ class Ghost(object):
         else:
             self.nvim.vars["ghost_cmd"] = self.cmd
 
+        self.darwin_app = self.nvim.vars.get("ghost_darwin_app")
+
         self.httpserver = MyHTTPServer(self, ('127.0.0.1', self.port),
                                        WebRequestHandler)
         http_server_thread = Thread(target=start_http_server,
@@ -172,12 +174,6 @@ class Ghost(object):
         elif "ghost_nvim_window_id" in self.nvim.vars:
             # for linux
             self.linux_window_id = self.nvim.vars["ghost_nvim_window_id"].strip()
-        elif sys.platform.startswith('darwin'):
-            if os.getenv('ITERM_PROFILE', None):
-                self.darwinapp = "iTerm2"
-            elif os.getenv('TERM_PROGRAM', None) == 'Apple_Terminal':
-                self.darwinapp = "Terminal"
-            logger.debug("%s detected" % self.darwinapp)
 
     @neovim.command('GhostStop', range='', nargs='0', sync=True)
     def server_stop(self, args, range):
@@ -263,10 +259,10 @@ class Ghost(object):
                     self.winapp.windows()[0].ShowInTaskbar()
                 except Exception as e:
                     logger.warning("Error during _raise_window, %s", e)
-            elif self.darwinapp:
+            elif self.darwin_app:
                 logger.debug("Darwin: trying to raise window")
                 subprocess.call(["osascript", "-e",
-                                 'tell application "' + self.darwinapp +
+                                 'tell application "' + self.darwin_app +
                                  '" to activate'])
         except Exception as e:
             # with vim yarp etc - letting an exception escape messes


### PR DESCRIPTION
Allows the user to do:

```viml
" e.g.  'Terminal', 'iTerm2', 'VimR', 'MacVim', 'kitty'
let g:ghost_darwin_app = 'VimR'
```

to have GhostText automatically focus the right app on macOS. Removes
the existing checks.

Refs: https://github.com/raghur/vim-ghost/pull/18#issuecomment-420541637