### PR TITLE
Show version  skeleton

### DIFF
--- a/doc/ghost.txt
+++ b/doc/ghost.txt
@@ -81,6 +81,8 @@ in the plugin folder to install required python dependencies.
 
 You can shutdown the server with :GhostStop
 
+For showing version information there is :GhostVersion
+
 
 ================================================================================
 Configuration                                               *GhostConfiguration*

--- a/plugin/vim_compat.vim
+++ b/plugin/vim_compat.vim
@@ -10,3 +10,4 @@ endfunc
 
 com! -nargs=0 GhostStart call s:ghost.call('server_start')
 com! -nargs=0 GhostStop call s:ghost.call('server_stop')
+com! -nargs=0 GhostVersion call s:ghost.call('show_version')

--- a/rplugin/python3/ghost.py
+++ b/rplugin/python3/ghost.py
@@ -190,6 +190,12 @@ class Ghost(object):
         self.echo("Ghost server stopped")
         self.server_started = False
 
+    @neovim.command('GhostVersion', range='', nargs='0', sync=True)
+    def show_version(self, args, range):
+        version_string = 'This is version FIXME'
+        logger.info(version_string)
+        self.echo(version_string)
+
     @neovim.function("GhostNotify")
     def ghost_notify(self, args):
         logger.info(args)


### PR DESCRIPTION
To make it possible that an user can tell which version is in use.

Note that an actual version string has to be found.
For now it is marked with a FIXME