### PR TITLE
Use Neovim jobs to shorten startup

### DIFF
--- a/autoload/ghost.vim
+++ b/autoload/ghost.vim
@@ -10,6 +10,7 @@ endfunction
 function! s:startGhost(tid)
     " during first installation, neovim has to be restarted after
     " :UpdateRemotePlugins
+    call s:SetWindowId()
     if !exists(":GhostStart")
         echom ":GhostStart not found. If you just installed vim-ghost, please restart nvim"
         return
@@ -17,13 +18,19 @@ function! s:startGhost(tid)
     GhostStart
 endfunction
 
-function! ghost#load()
+function! s:SetWindowId()
+    if exists("g:ghost_nvim_window_id")
+        return
+    endif
     if executable("xdotool")
         let g:ghost_nvim_window_id = system("xdotool getactivewindow")
         return
     endif
+endfunction
 
+function! ghost#load()
     if !has('timers')
+        call s:SetWindowId()
         return
     endif
 


### PR DESCRIPTION
Today I noticed vim-ghost is the slowest startup script in my plugins. Here's the line from my log of `--startuptime`:

```
287.110  070.992  070.930 sourcing /home/doron/.files/.config/nvim/pack/functional/start/ghost/plugin/ghost.vim
```

But with this change, it's:

```
193.265  001.152  001.121 sourcing /home/doron/.files/.config/nvim/pack/functional/start/ghost/plugin/ghost.vim
```

Which is significant.

It may be possible to do this in a Vim8 compatible manner but I first wish to get your feedback.

P.S

I also added another small change to the end of `ghost#load` which may be a tiny bit more performant. But it's not related.

Regards.