### PR TITLE
Make `s:initGhost` accept varargs

### DIFF
--- a/autoload/ghost.vim
+++ b/autoload/ghost.vim
@@ -7,7 +7,7 @@ function! ghost#install()
     endif
 endfunction
 
-function! s:initGhost()
+function! s:initGhost(...)
     " init ghost - capture window id to raise if necessary (*nix only)
     " Then if autostart is enabled, then start
     call s:SetWindowId()


### PR DESCRIPTION
`timer_start` sends the timer ID as argument, so it needs to be 
swallowed somehow. Making `s:initGhost` accept varargs is the simplest
way to acheive this.