### PR TITLE
Typo in example for ghost_darwin_app

### DIFF
--- a/doc/ghost.txt
+++ b/doc/ghost.txt
@@ -132,7 +132,7 @@ You can check by running this command from inside vim:
 <
 Examples: 'Terminal', 'iTerm2', 'VimR', 'MacVim', 'kitty'
 >
-    let g:ghost_cmd = 'Terminal'
+    let g:ghost_darwin_app = 'Terminal'
 <
 Default: ''
 


### PR DESCRIPTION
Hi,

I came across a small typo in the documentation, maybe it's worth fixing :)

Regards, 

-- Michael 