### PR TITLE
Added 1 configuration variable and 2 new commands:

### DIFF
--- a/doc/ghost.txt
+++ b/doc/ghost.txt
@@ -150,6 +150,18 @@ Syntax Highlighting
     autocmd BufNewFile,BufRead *stackoverflow.com* set filetype=markdown
     augroup END
 
+--------------------------------------------------------------------------------
+                                                                *g:ghost_enable_sync*
+Enable real-time syncing of the browser's textarea.
+
+  By default, anything you type in vim appears immediately in the browser's textarea.
+  If disabled, manual syncing of the textarea is done with the :GhostSync command.
+  Syncing may be disabled / enabled on the fly using the :GhostToggleSync command.
+>
+    let g:ghost_enable_sync = 1
+<
+Default: 1
+
 ================================================================================
 Contributing                                                 *GhostContributing*
 

--- a/plugin/vim_compat.vim
+++ b/plugin/vim_compat.vim
@@ -10,3 +10,5 @@ endfunc
 
 com! -nargs=0 GhostStart call s:ghost.call('server_start')
 com! -nargs=0 GhostStop call s:ghost.call('server_stop')
+com! -nargs=0 GhostToggleSync call s:ghost.call('ghost_toggle_sync')
+com! -nargs=0 GhostSync call s:ghost.call('ghost_sync')

--- a/pythonx/ghost_wrapper.py
+++ b/pythonx/ghost_wrapper.py
@@ -9,5 +9,11 @@ def server_start(*args):
 def server_stop(*args):
     return _obj.server_stop(args, '')
 
+def ghost_toggle_sync(*args):
+    return _obj.ghost_toggle_sync(args, '')
+
+def ghost_sync(*args):
+    return _obj.ghost_sync(args, '')
+
 def ghost_notify(*args):
     return _obj.ghost_notify(args)


### PR DESCRIPTION
g:ghost_enable_sync (default: 1)

:GhostToggleSync
:GhostSync

By default, Ghost synchronizes the content of the Vim buffer with the browser's textarea (normal behavior). If ghost_enable_sync is set to 0, Ghost only updates the textarea when the :GhostSync command is issued. While editing, :GhostToggleSync may be used to disable / enable syncing.

The purpose of this modification is to allow the user to control exactly when the textarea should receive an update. This was done specifically for Discourse forums, in which other forum users can see someone is in the process of replying. Discourse does not allow users to disable this. Using vim-ghost with syncing disabled, nobody on a Discourse forum is made aware that a reply is being typed until the very last syncing of the reply's textarea.